### PR TITLE
Fix: 드랍 아이템 삭제시 적용된 탭도 기본화면으로 변하게 수정

### DIFF
--- a/src/components/ObjectPage/ObjectCanvas.jsx
+++ b/src/components/ObjectPage/ObjectCanvas.jsx
@@ -69,14 +69,12 @@ const ObjectCanvas = ({
 			setDroppedItems(prevItems =>
 				prevItems.filter(item => item.id !== id),
 			);
-			setActiveTab(prevCategory =>
-				prevCategory === category ? null : category,
-			);
 		}
 		// 기본 아이템인 경우 유지
 
 		setSelectedItemId(null);
 		setIsColorPickerOpen(false);
+		setActiveTab(null);
 	};
 	return (
 		<View style={styles.canvas}>


### PR DESCRIPTION
오브젝트 화면 시연 영상 찍으면서 수정한 부분 입니다!

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/00fd65db-2802-4549-b3f7-222f5c9f945b" width="300" alt="탭 수정전"></td>
    <td><img src="https://github.com/user-attachments/assets/fd7d0a52-ff60-43c1-a54a-d01bb357df2f" width="300" alt="탭 수정후"></td>
  </tr>
</table>

